### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aecomet/backoff-util",
-  "version": "1.0.11",
+  "version": "2.0.0",
   "description": "A utility to use retry any functions",
   "keywords": [
     "exponential backoff",


### PR DESCRIPTION
Version bump after DI refactoring. Published to npm as @aecomet/backoff-util@2.0.0