### PR TITLE
chore: update dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: 'chore: npm'
     open-pull-requests-limit: 5
@@ -16,7 +16,7 @@ updates:
     assignees:
       - aecomet
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: 'chore: actions'
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Update dependabot schedule from weekly to monthly
- Reduce PR noise and batch dependency updates

## Changes

- .github/dependabot.yml: interval weekly → monthly

## Verification

- [x] pnpm format passes
- [x] pnpm lint passes
- [x] pnpm test passes (20 tests)
- [x] pnpm build passes