### PR TITLE
feat: add remaining/nextDelay to context and cancelable sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const result = await utility.backoff(async () => {
 | `factor`      | `number`                               | `2`             | Multiplier for exponential delay (`minDelay * factor^attempt`) |
 | `jitter`      | `'full' \| 'none'`                     | `'full'`        | Jitter strategy, or a custom function                          |
 | `shouldRetry` | `(ctx: BackoffContext) => boolean`     | retry always    | Return `false` to stop retrying immediately                    |
-| `onRetry`     | `(ctx: BackoffContext) => void`        | `console.warn`  | Called on each retry for logging or side effects               |
+| `onRetry`     | `(ctx: BackoffContext) => void`        | none            | Called on each retry for logging or side effects               |
 | `timeoutMs`   | `number`                               | none            | Total elapsed time limit (ms); throws when exceeded            |
 | `signal`      | `AbortSignal`                          | none            | Cancels the retry loop when the signal is aborted              |
 
@@ -106,11 +106,41 @@ const utility = new Utility({
 
 Callbacks receive a context object:
 
-| Field     | Type      | Description                                  |
-| --------- | --------- | -------------------------------------------- |
-| `attempt` | `number`  | Current attempt index (0-based)              |
-| `error`   | `unknown` | The error that caused the retry              |
-| `elapsed` | `number`  | Total elapsed time since the first call (ms) |
+| Field       | Type                    | Description                                       |
+| ----------- | ----------------------- | ------------------------------------------------- |
+| `attempt`   | `number`                | Current attempt index (0-based)                   |
+| `error`     | `unknown`               | The error that caused the retry                   |
+| `elapsed`   | `number`                | Total elapsed time since the first call (ms)      |
+| `remaining` | `number`                | Number of retries left (including current)        |
+| `nextDelay` | `number` \| `undefined` | Next wait time in ms (undefined on final attempt) |
+
+## OpenTelemetry integration
+
+`onRetry` receives a `BackoffContext` with `attempt`, `remaining`, `nextDelay`, and `error`.
+Use it to emit retry telemetry from your application's tracer:
+
+```js
+import { trace } from '@opentelemetry/api';
+import { Utility } from '@aecomet/backoff-util';
+
+const tracer = trace.getTracer('http-client');
+
+const utility = new Utility({
+  retryCount: 5,
+  onRetry: (ctx) => {
+    tracer.startActiveSpan('http.retry', (span) => {
+      span.setAttribute('retry.attempt', ctx.attempt);
+      span.setAttribute('retry.remaining', ctx.remaining);
+      span.setAttribute('retry.next_delay_ms', ctx.nextDelay ?? 0);
+      span.setAttribute('retry.elapsed_ms', ctx.elapsed);
+      if (ctx.error instanceof Error) {
+        span.recordException(ctx.error);
+      }
+      span.end();
+    });
+  }
+});
+```
 
 ## Examples
 

--- a/__tests__/integration/utility.test.ts
+++ b/__tests__/integration/utility.test.ts
@@ -53,7 +53,9 @@ describe('Utility', () => {
     expect(onRetry).toHaveBeenCalledWith({
       attempt: 0,
       error: expect.any(Error),
-      elapsed: expect.any(Number)
+      elapsed: expect.any(Number),
+      remaining: 5,
+      nextDelay: expect.any(Number)
     });
   });
 
@@ -84,11 +86,14 @@ describe('Utility', () => {
     const util = new Utility({ retryCount: 5, minDelay: 10, maxDelay: 100, delay: customDelay, jitter: 'none' });
     await util.backoff(fn);
 
-    expect(customDelay).toHaveBeenCalledWith({
-      attempt: 0,
-      error: expect.any(Error),
-      elapsed: expect.any(Number)
-    });
+    expect(customDelay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 0,
+        error: expect.any(Error),
+        elapsed: expect.any(Number),
+        remaining: 5
+      })
+    );
   });
 
   test('accepts custom jitter function (DI point)', async () => {
@@ -99,5 +104,94 @@ describe('Utility', () => {
     await util.backoff(fn);
 
     expect(customJitter).toHaveBeenCalledWith(10);
+  });
+
+  test('context includes remaining retry count', { timeout: 10000 }, async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('e'));
+    const delays: number[] = [];
+    const util = new Utility({
+      retryCount: 3,
+      minDelay: 1,
+      maxDelay: 5,
+      jitter: 'none',
+      delay: (ctx) => {
+        delays.push(ctx.remaining);
+        return 1;
+      }
+    });
+
+    await util.backoff(fn).catch(() => {});
+
+    expect(delays).toEqual([3, 2, 1]);
+  });
+
+  test('onRetry receives nextDelay for telemetry', { timeout: 10000 }, async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn().mockRejectedValueOnce(new Error('e1')).mockResolvedValueOnce('ok');
+    const util = new Utility({
+      retryCount: 5,
+      minDelay: 100,
+      maxDelay: 100,
+      jitter: 'none',
+      onRetry
+    });
+
+    await util.backoff(fn);
+
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 0,
+        remaining: 5,
+        nextDelay: 100
+      })
+    );
+  });
+
+  test('onRetry receives undefined nextDelay on final attempt', { timeout: 10000 }, async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn().mockRejectedValue(new Error('always fails'));
+    const util = new Utility({ retryCount: 1, minDelay: 1, maxDelay: 5, jitter: 'none', onRetry });
+
+    await util.backoff(fn).catch(() => {});
+
+    expect(onRetry).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        remaining: 0,
+        nextDelay: undefined
+      })
+    );
+  });
+
+  test('aborts immediately during delay when signal is triggered', async () => {
+    const controller = new AbortController();
+    const fn = vi.fn().mockRejectedValueOnce(new Error('e1')).mockRejectedValue(new Error('e2'));
+    const util = new Utility({
+      retryCount: 5,
+      minDelay: 1000,
+      maxDelay: 1000,
+      jitter: 'none',
+      signal: controller.signal
+    });
+
+    setTimeout(() => controller.abort(), 10);
+    const start = Date.now();
+    await expect(util.backoff(fn)).rejects.toThrow('Backoff aborted.');
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  test('respects timeout during delay without waiting for full delay', { timeout: 10000 }, async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('slow'));
+    const util = new Utility({
+      retryCount: 100,
+      minDelay: 10000,
+      maxDelay: 10000,
+      jitter: 'none',
+      timeoutMs: 50
+    });
+
+    const start = Date.now();
+    await expect(util.backoff(fn)).rejects.toThrow('timed out');
+    expect(Date.now() - start).toBeLessThan(500);
   });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,8 @@ Configuration interface passed to the `Utility` constructor. All properties are 
 | `attempt` | `number`  | Current attempt index (0-based)          |
 | `error`   | `unknown` | The error that caused the retry          |
 | `elapsed` | `number`  | Total elapsed time since the first call (ms) |
+| `remaining` | `number`  | Number of retries left (including current) |
+| `nextDelay` | `number` \| `undefined` | Next wait time in ms (undefined on final attempt) |
 
 ### `DelayFn`
 
@@ -151,11 +153,45 @@ for attempt = 0; attempt <= retryCount; attempt++:
   3. check signal.aborted → throw AbortError
   4. check timeoutMs → throw Error if exceeded
   5. check shouldRetry(ctx) → rethrow if returns false
-  6. call onRetry(ctx) if provided
-  7. rawDelay = delay(ctx)
-  8. wait = jitter(rawDelay)
-  9. sleep(wait ms)
+  6. if attempt < retryCount: nextDelay = jitter(delay(ctx))
+  7. call onRetry(ctx) with nextDelay if provided
+  8. if attempt == retryCount → break (no delay after the final failure)
+  9. sleep(nextDelay ms), aborted by signal / timeout during sleep
 throw Error("Over retry")
+```
+
+## Retry Flow (Sequence Diagram)
+
+The following sequence diagram illustrates the retry behavior of `backoff`:
+
+```mermaid
+sequenceDiagram
+  participant C as Caller
+  participant U as Utility
+  participant F as Callback
+
+  C->>U: backoff(callback)
+  loop attempt 0..retryCount
+    U->>F: invoke callback()
+    alt success
+      F-->>U: result
+      U-->>C: result
+    else error
+      F-->>U: throw error
+      alt signal aborted
+        U-->>C: throw AbortError
+      else timeoutMs exceeded
+        U-->>C: throw "Backoff timed out."
+      else shouldRetry(ctx) returns false
+        U-->>C: rethrow original error
+      else retry
+        U->>U: delay(ctx) + jitter
+        note over U: waits (cancelable by signal / timeout)
+        U->>U: retry attempt +1
+      end
+    end
+  end
+  U-->>C: throw "Over retry"
 ```
 
 ## Build Output

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface BackoffContext {
   attempt: number;
   error?: unknown;
   elapsed: number;
+  remaining: number;
+  nextDelay?: number;
 }
 
 export type DelayFn = (ctx: BackoffContext) => number;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -66,16 +66,63 @@ export class Utility {
           throw new Error('Backoff timed out.');
         }
 
-        const ctx: BackoffContext = { attempt: i, error, elapsed };
+        const isLastAttempt = i === retryCount;
+        const ctx: BackoffContext = { attempt: i, error, elapsed, remaining: retryCount - i, nextDelay: undefined };
+
         if (shouldRetry && !shouldRetry(ctx)) throw error;
+
+        let waitTime = 0;
+        if (!isLastAttempt) {
+          const raw = delay(ctx);
+          waitTime = jitter(raw);
+          ctx.nextDelay = waitTime;
+        }
 
         if (onRetry) onRetry(ctx);
 
-        const raw = delay(ctx);
-        const waitTime = jitter(raw);
-        await new Promise((r) => setTimeout(r, waitTime));
+        if (isLastAttempt) break;
+
+        await this.sleep(waitTime, startTime, timeoutMs, signal);
       }
     }
     throw new Error('Over retry, all the callback caused unexpected errors.');
+  }
+
+  private sleep(
+    waitTime: number,
+    startTime: number,
+    timeoutMs: number | undefined,
+    signal: AbortSignal | undefined
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, waitTime);
+
+      const onAbort = () => {
+        cleanup();
+        reject(new DOMException('Backoff aborted.', 'AbortError'));
+      };
+
+      const checkTimeout = () => {
+        cleanup();
+        reject(new Error('Backoff timed out.'));
+      };
+
+      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs !== undefined) {
+        const remaining = timeoutMs - (Date.now() - startTime);
+        timeoutTimer = setTimeout(checkTimeout, Math.max(remaining, 0));
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+
+      function cleanup() {
+        clearTimeout(timer);
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        signal?.removeEventListener('abort', onAbort);
+      }
+    });
   }
 }


### PR DESCRIPTION
## What's Changed

### Context improvements (for telemetry / finer control)
- `BackoffContext` now includes:
  - `remaining` — number of retries left (including current attempt)
  - `nextDelay` — next wait time in ms (undefined on final attempt), passed to `onRetry`
- `onRetry` now receives `nextDelay`, enabling OpenTelemetry integration from the application side

### Fixes
- **Wasted sleep after final attempt**: the delay was calculated and waited even after the last failed attempt. Now the loop breaks immediately after the final failure.
- **Cancelable sleep**: `AbortSignal` abort and `timeoutMs` expiry are now detected immediately during the delay wait (previously only checked between attempts).

### Docs
- `docs/architecture.md`: added Mermaid sequence diagram of the retry flow
- `README.md`: added OpenTelemetry integration example, fixed `onRetry` default value description

### Tests
- 20 → 25 tests, all passing
- Added tests for: remaining, nextDelay on retry / final attempt, immediate abort during delay, immediate timeout during delay